### PR TITLE
fix: replace deprecated ephemeral option with MessageFlags.Ephemeral

### DIFF
--- a/src/buttons/Queue.ts
+++ b/src/buttons/Queue.ts
@@ -4,6 +4,7 @@ import {
   EmbedBuilder,
   InteractionCollector,
   Message,
+  MessageFlags,
 } from 'discord.js'
 import { PlayerButton } from '../@types/Button.js'
 import { Manager } from '../manager.js'
@@ -72,6 +73,6 @@ export default class implements PlayerButton {
 
       pages.push(embed)
     }
-    message.reply({ embeds: [pages[0]], ephemeral: true })
+    message.reply({ embeds: [pages[0]], flags: MessageFlags.Ephemeral })
   }
 }

--- a/src/buttons/Shuffle.ts
+++ b/src/buttons/Shuffle.ts
@@ -4,6 +4,7 @@ import {
   EmbedBuilder,
   InteractionCollector,
   Message,
+  MessageFlags,
   User,
 } from 'discord.js'
 import { PlayerButton } from '../@types/Button.js'
@@ -104,6 +105,6 @@ export default class implements PlayerButton {
         message,
         qduration
       )
-    } else message.reply({ embeds: [pages[0]], ephemeral: true })
+    } else message.reply({ embeds: [pages[0]], flags: MessageFlags.Ephemeral })
   }
 }

--- a/src/commands/Music/Insert.ts
+++ b/src/commands/Music/Insert.ts
@@ -1,7 +1,7 @@
 import {
   ApplicationCommandOptionType,
   AutocompleteInteraction,
-  CommandInteraction,
+  ChatInputCommandInteraction,
   EmbedBuilder,
 } from 'discord.js'
 import { Manager } from '../../manager.js'
@@ -133,7 +133,7 @@ export default class implements Command {
   // Autocomplete function
   async autocomplete(client: Manager, interaction: GlobalInteraction, language: string) {
     let choice: AutocompleteInteractionChoices[] = []
-    const url = String((interaction as CommandInteraction).options.get('search')!.value)
+    const url = String((interaction as ChatInputCommandInteraction).options.get('search')!.value)
 
     const Random =
       client.config.player.AUTOCOMPLETE_SEARCH[

--- a/src/commands/Music/Play.ts
+++ b/src/commands/Music/Play.ts
@@ -1,7 +1,7 @@
 import {
   ApplicationCommandOptionType,
   AutocompleteInteraction,
-  CommandInteraction,
+  ChatInputCommandInteraction,
   EmbedBuilder,
 } from 'discord.js'
 import { convertTime } from '../../utilities/ConvertTime.js'
@@ -183,7 +183,7 @@ export default class implements Command {
   // Autocomplete function
   async autocomplete(client: Manager, interaction: GlobalInteraction, language: string) {
     let choice: AutocompleteInteractionChoices[] = []
-    const url = String((interaction as CommandInteraction).options.get('search')!.value)
+    const url = String((interaction as ChatInputCommandInteraction).options.get('search')!.value)
 
     const maxLength = await client.db.maxlength.get(interaction.user.id)
 

--- a/src/commands/Music/Radio.ts
+++ b/src/commands/Music/Radio.ts
@@ -3,6 +3,7 @@ import {
   ApplicationCommandOptionType,
   ComponentType,
   EmbedBuilder,
+  MessageFlags,
   StringSelectMenuBuilder,
   StringSelectMenuOptionBuilder,
 } from 'discord.js'
@@ -165,7 +166,7 @@ export default class implements Command {
       const msgReply = await message
         .reply({
           embeds: [replyEmbed],
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         })
         .catch(() => {})
       if (msgReply)

--- a/src/commands/Playlist/Add.ts
+++ b/src/commands/Playlist/Add.ts
@@ -1,7 +1,7 @@
 import {
   EmbedBuilder,
   ApplicationCommandOptionType,
-  CommandInteraction,
+  ChatInputCommandInteraction,
   AutocompleteInteraction,
 } from 'discord.js'
 import { convertTime } from '../../utilities/ConvertTime.js'
@@ -220,7 +220,7 @@ export default class implements Command {
   // Autocomplete function
   public async autocomplete(client: Manager, interaction: GlobalInteraction, language: string) {
     let choice: AutocompleteInteractionChoices[] = []
-    const url = String((interaction as CommandInteraction).options.get('search')!.value)
+    const url = String((interaction as ChatInputCommandInteraction).options.get('search')!.value)
 
     const maxLength = await client.db.maxlength.get(interaction.user.id)
 

--- a/src/commands/Playlist/Editor.ts
+++ b/src/commands/Playlist/Editor.ts
@@ -2,7 +2,7 @@ import {
   EmbedBuilder,
   ApplicationCommandOptionType,
   Message,
-  CommandInteraction,
+  ChatInputCommandInteraction,
   ActionRowBuilder,
   TextInputBuilder,
   ModalBuilder,
@@ -42,7 +42,7 @@ export default class implements Command {
     if (handler.message) {
       await this.prefixMode(client, handler.message, handler.args, handler.language, handler.prefix)
     } else if (handler.interaction) {
-      await this.interactionMode(client, handler.interaction, handler.language)
+      await this.interactionMode(client, handler.interaction as ChatInputCommandInteraction, handler.language)
     } else return
   }
 
@@ -259,7 +259,7 @@ export default class implements Command {
   // Interaction mode
   private async interactionMode(
     client: Manager,
-    interaction: CommandInteraction,
+    interaction: ChatInputCommandInteraction,
     language: string
   ) {
     const playlistId = new TextInputBuilder()
@@ -314,7 +314,7 @@ export default class implements Command {
         new ActionRowBuilder<TextInputBuilder>().addComponents(playlistPrivate)
       )
 
-    const value = (interaction.options as CommandInteractionOptionResolver).getString('id')
+    const value = (interaction as ChatInputCommandInteraction).options.getString('id')
 
     const playlist = await client.db.playlist.get(value!)
 

--- a/src/events/guild/messageCreate.ts
+++ b/src/events/guild/messageCreate.ts
@@ -113,7 +113,10 @@ export default class {
       return
     }
     const escapeRegex = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    const prefixRegex = new RegExp(`^(<@!?${client.user!.id}>|${escapeRegex(PREFIX.toLowerCase())})\\s*`, 'i')
+    const prefixRegex = new RegExp(
+      `^(<@!?${client.user!.id}>|${escapeRegex(PREFIX.toLowerCase())})\\s*`,
+      'i'
+    )
     if (!prefixRegex.test(message.content)) return
     const [matchedPrefix] = message.content.match(prefixRegex) as RegExpMatchArray
     const args = message.content.slice(matchedPrefix.length).trim().split(/ +/g)

--- a/src/events/track/trackStart.ts
+++ b/src/events/track/trackStart.ts
@@ -1,5 +1,5 @@
 import { Manager } from '../../manager.js'
-import { ComponentType, TextChannel } from 'discord.js'
+import { ComponentType, TextChannel, MessageFlags } from 'discord.js'
 import { EmbedBuilder } from 'discord.js'
 import { formatDuration } from '../../utilities/FormatDuration.js'
 import { filterSelect, playerRowOne, playerRowTwo } from '../../utilities/PlayerControlButton.js'
@@ -142,7 +142,7 @@ export default class {
         else {
           message.reply({
             content: `${client.i18n.get(language, 'event.player', 'join_voice')}`,
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
           })
           return false
         }
@@ -160,7 +160,7 @@ export default class {
         else {
           message.reply({
             content: `${client.i18n.get(language, 'event.player', 'join_voice')}`,
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
           })
           return false
         }

--- a/src/services/ReplyInteractionService.ts
+++ b/src/services/ReplyInteractionService.ts
@@ -16,13 +16,12 @@ export class ReplyInteractionService {
     const msg = await this.message
       .reply({
         embeds: [embed],
-        ephemeral: false,
       })
       .catch(() => null)
     const setup = await this.client.db.setup.get(String(this.message.guildId))
 
     setTimeout(() => {
-      (!setup || setup == null || setup.channel !== this.message.channelId) && msg
+      ;(!setup || setup == null || setup.channel !== this.message.channelId) && msg
         ? msg.delete().catch(() => null)
         : true
     }, this.client.config.utilities.DELETE_MSG_TIMEOUT)

--- a/src/structures/CommandHandler.ts
+++ b/src/structures/CommandHandler.ts
@@ -138,7 +138,7 @@ export class CommandHandler {
 
   public async deferReply() {
     if (this.interaction) {
-      const data = await this.interaction.deferReply({ ephemeral: false })
+      const data = await this.interaction.deferReply()
       return (this.msg = data)
     } else {
       const data = await this.message?.reply(`**${this.client.user?.username}** is thinking...`)

--- a/src/structures/PageQueue.ts
+++ b/src/structures/PageQueue.ts
@@ -7,6 +7,7 @@ import {
   ComponentType,
   EmbedBuilder,
   Message,
+  MessageFlags,
 } from 'discord.js'
 import { Manager } from '../manager.js'
 
@@ -425,7 +426,7 @@ export class PageQueue {
       ],
       components: [row],
       allowedMentions: { repliedUser: false },
-      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     })
     if (this.pages.length == 0) return
 


### PR DESCRIPTION
## Changes
- Fixed deprecation warning for ephemeral interaction responses in Discord.js v14+
- Replaced `ephemeral: true` with `flags: MessageFlags.Ephemeral`
- Replaced `CommandInteraction` with `ChatInputCommandInteraction` for proper typing
- Removed unnecessary `ephemeral: false` (default value)

## Files Changed
- src/buttons/Queue.ts
- src/buttons/Shuffle.ts
- src/commands/Music/Insert.ts
- src/commands/Music/Play.ts
- src/commands/Music/Radio.ts
- src/commands/Playlist/Add.ts
- src/commands/Playlist/Editor.ts
- src/events/track/trackStart.ts
- src/services/ReplyInteractionService.ts
- src/structures/CommandHandler.ts
- src/structures/PageQueue.ts

## Testing
- Bot runs without deprecation warnings
- All commands work as expected